### PR TITLE
Restricting user update on save to Craft Pro only

### DIFF
--- a/foxycart/FoxyCartPlugin.php
+++ b/foxycart/FoxyCartPlugin.php
@@ -45,9 +45,11 @@ class FoxyCartPlugin extends BasePlugin
         }
 
         craft()->on('users.onSaveUser', function(Event $event) {
-            $customerId = craft()->foxyCart->updateFoxyCartCustomer($event->params['user']);
-            if ($customerId) {
-                craft()->foxyCart->saveCustomerId($event->params['user'], $customerId);
+            if (craft()->getEdition() == Craft::Pro) {
+                $customerId = craft()->foxyCart->updateFoxyCartCustomer($event->params['user']);
+                if ($customerId) {
+                    craft()->foxyCart->saveCustomerId($event->params['user'], $customerId);
+                }
             }
         });
     }


### PR DESCRIPTION
The `updateFoxyCartCustomer()` function was being called on the `onSaveUser` event, but it's functionality that requires Craft Pro. As such, for anyone not on Craft Pro it was triggering a permissions error when trying to save any user. This change ensures that that only happens if the Craft installation has the Pro edition.

Resolves #1 
