### PR TITLE
Updating templates to account for some data potentially not being present

### DIFF
--- a/foxycart/templates/customer.html
+++ b/foxycart/templates/customer.html
@@ -10,7 +10,10 @@
 ] %}
 
 {% if customer != false %}
-	{% set title = title~": "~customer.customer_first_name~" "~customer.customer_last_name %}
+    {% set customer_name = [] %}
+    {% if customer.customer_first_name %}{% set customer_name = customer_name|merge([customer.customer_first_name]) %}{% endif %}
+    {% if customer.customer_last_name %}{% set customer_name = customer_name|merge([customer.customer_last_name]) %}{% endif %}
+	{% set title = title~": "~customer_name|join(" ") %}
 {% endif %}
 
 {% set extraPageHeaderHtml %}
@@ -34,7 +37,7 @@
 	{% else %}
 		<dl class="fc">
 			<dt>Name</dt>
-			<dd>{{ customer.customer_first_name }} {{ customer.customer_last_name }}</dd>
+			<dd>{% if customer.customer_first_name %}{{ customer.customer_first_name }}{% endif %} {% if customer.customer_last_name %}{{ customer.customer_last_name }}{% endif %}</dd>
 			{% if customer.customer_company is not empty %}
 				<dt>Company</dt>
 				<dd>{{ customer.customer_company }}</dd>
@@ -43,12 +46,12 @@
 			<dd>{{ customer.customer_email }}</dd>
 			<dt>Address</dt>
 			<dd>
-				{{ customer.customer_address1 }}<br/>
+				{% if customer.customer_address1 is not empty %}{{ customer.customer_address1 }}{% endif %}<br/>
 				{% if customer.customer_address2 is not empty %}
 					{{ customer.customer_address2 }}<br/>
 				{% endif %}
-				{{ customer.customer_city }}, {{ customer.customer_state }}<br/>
-				{{ customer.customer_country }} {{ customer.customer_postal_code }}
+				{% if customer.customer_city is not empty %}{{ customer.customer_city }}{% endif %}, {% if customer.customer_state is not empty %}{{ customer.customer_state }}{% endif %}<br/>
+				{% if customer.customer_country is not empty %}{{ customer.customer_country }}{% endif %} {% if customer.customer_postal_code is not empty %}{{ customer.customer_postal_code }}{% endif %}
 			</dd>
 			{% if customer.customer_phone is not empty %}
 				<dt>Phone</dt>

--- a/foxycart/templates/customers.html
+++ b/foxycart/templates/customers.html
@@ -43,10 +43,10 @@
 	{% else %}
 		{% for customer in customers %}
 			<tr>
-				<td><a href="{{ url('foxycart/customer/'~customer.customer_id) }}">{{ customer.customer_first_name }} {{ customer.customer_last_name }}</a></td>
+				<td><a href="{{ url('foxycart/customer/'~customer.customer_id) }}">{% if customer.customer_first_name %}{{ customer.customer_first_name }}{% endif %} {% if customer.customer_last_name %}{{ customer.customer_last_name }}{% endif %}</a></td>
 				<td>{{ customer.customer_email }}</td>
-				<td>{{ customer.customer_country }}</td>
-				<td>{{ customer.customer_postal_code }}</td>
+				<td>{% if customer.customer_country %}{{ customer.customer_country }}{% endif %}</td>
+				<td>{% if customer.customer_postal_code %}{{ customer.customer_postal_code }}{% endif %}</td>
 			</tr>
 		{% endfor %}
 	{% endif %}

--- a/foxycart/templates/index.html
+++ b/foxycart/templates/index.html
@@ -48,7 +48,7 @@
 			{% for transaction in transactions %}
 				<tr>
 					<td><a target="_blank" href="{{ transaction.receipt_url }}" class="go" title="{{ "View receipt"|t }}">{{ transaction.id }}</a></td>
-					<td>{% if transaction.is_anonymous == "0" %}<a target="_blank" href="{{ url('foxycart/customer/'~transaction.customer_id) }}" title="{{ "View Customer"|t }}">{% endif %}{{ transaction.customer_first_name }} {{ transaction.customer_last_name }}{% if transaction.is_anonymous == "0" %}</a>{% endif %}</td>
+					<td>{% if transaction.is_anonymous == "0" %}<a target="_blank" href="{{ url('foxycart/customer/'~transaction.customer_id) }}" title="{{ "View Customer"|t }}">{% endif %}{% if transaction.customer_first_name %}{{ transaction.customer_first_name }}{% endif %} {% if transaction.customer_last_name %}{{ transaction.customer_last_name }}{% endif %}{% if transaction.is_anonymous == "0" %}</a>{% endif %}</td>
 					<td>{{ transaction.customer_email }}</td>
 					<td>{{ transaction.order_total|currency('$') }}</td>
 					<td>{{ transaction.transaction_date|datetime }}</td>


### PR DESCRIPTION
Resolves #5 

Not all customer data is required, and the legacy API response for blank values is interpreted as an empty array. When the Twig tries to output that as a string, it triggers an error.

This fix adds if conditionals around those values so it's only output if the value is present.